### PR TITLE
Removed duplicate call to adjustSlicesZPosition

### DIFF
--- a/src/main/java/ch/epfl/biop/atlas/aligner/commands/RegistrationDeepSliceCommand.java
+++ b/src/main/java/ch/epfl/biop/atlas/aligner/commands/RegistrationDeepSliceCommand.java
@@ -177,10 +177,6 @@ public class RegistrationDeepSliceCommand implements Command {
             adjustSlicesZPosition(slicesToExport, nPixX, nPixY);
         }
 
-        if (allowChangeSlicingPosition) {
-            adjustSlicesZPosition(slicesToExport, nPixX, nPixY);
-        }
-
         if (affineTransform) {
             try {
                 affineTransformInPlane(slicesToExport, nPixX, nPixY);


### PR DESCRIPTION
Hi Nicolas,

Was just browsing through the code and saw the same step repeated twice in the DeepSlice command.  If it's there on purpose, please disregard.